### PR TITLE
updated wit-abi to a version that addresses the moving of wit-parser off of wit-bindgen - previous ones fail

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,6 +11,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-    - uses: WebAssembly/wit-abi-up-to-date@v2
+    - uses: WebAssembly/wit-abi-up-to-date@v6
       with:
-        wit-abi-tag: wit-abi-0.1.0
+        wit-abi-tag: wit-abi-0.6.0

--- a/proposal-template.abi.md
+++ b/proposal-template.abi.md
@@ -27,5 +27,5 @@ Size: 16, Alignment: 8
   Explanation for developers using the API.
 ##### Results
 
-- <a href="#api_function_one." name="api_function_one."></a> ``: [`api-type-one`](#api_type_one)
+- [`api-type-one`](#api_type_one)
 

--- a/proposal-template.wit.md
+++ b/proposal-template.wit.md
@@ -26,7 +26,7 @@ More rigorous specification details for the implementer go here, if needed.
 /// Short description
 ///
 /// Explanation for developers using the API.
-api-function-one: function() -> api-type-one
+api-function-one: func() -> api-type-one
 ```
 
 If needed, this would explain what a compliant implementation MUST do, such as never returning an earlier result from a later call.


### PR DESCRIPTION
The first run of this template fails in newly initialized repos:

<img width="1495" alt="image" src="https://user-images.githubusercontent.com/39843321/203455952-f8129f2f-60e2-497b-bf5f-b9ea29a7515a.png">

It would fail in the installation of `wit-abi`, because one of its dependencies (i.e., the `wit-parser` Rust crate) was moved from [`wit-bindgen`](https://github.com/bytecodealliance/wit-bindgen) to [wasm-tools](https://github.com/WebAssembly/wasi-tools). This was fixed here: https://github.com/WebAssembly/wasi-tools/pull/9.

This PR updates the template to spawn repos that use the latest `wit-abi` version in its workflows, changes from `function` to `func` in the `proposal-template.wit.md` file, and has changes in the `proposal-template.abi.md` that come from running `wit-abi` in the new `proposal-template.wit.md` file. 

Signed-off-by: danbugs <danilochiarlone@gmail.com>