### PR TITLE
Update to the latest wit-bindgen.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,6 +11,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-    - uses: WebAssembly/wit-abi-up-to-date@v6
+    - uses: WebAssembly/wit-abi-up-to-date@v10
       with:
-        wit-abi-tag: wit-abi-0.6.0
+        wit-abi-tag: wit-abi-0.7.0

--- a/proposal-template.html
+++ b/proposal-template.html
@@ -1,0 +1,24 @@
+<h1>Import interface <code>proposal-interface-name</code></h1>
+<h2>Types</h2>
+<h2><a href="#api_type_one" name="api_type_one"></a> <a href="#api_type_one"><code>api-type-one</code></a>: record</h2>
+<p>Short description</p>
+<p>Explanation for developers using the API.</p>
+<p>Size: 16, Alignment: 8</p>
+<h3>Record Fields</h3>
+<ul>
+<li>
+<p><a href="api_type_one.property1" name="api_type_one.property1"></a> <a href="#api_type_one.property1"><code>property1</code></a>: <code>u64</code></p>
+</li>
+<li>
+<p><a href="api_type_one.property2" name="api_type_one.property2"></a> <a href="#api_type_one.property2"><code>property2</code></a>: <code>string</code></p>
+</li>
+</ul>
+<h2>Functions</h2>
+<hr />
+<h4><a href="#api_function_one" name="api_function_one"></a> <a href="#api_function_one"><code>api-function-one</code></a></h4>
+<p>Short description</p>
+<p>Explanation for developers using the API.</p>
+<h5>Results</h5>
+<ul>
+<li><a href="#api_function_one.result0" name="api_function_one.result0"></a> <code>result0</code>: <a href="#api_type_one"><a href="#api_type_one"><code>api-type-one</code></a></a></li>
+</ul>

--- a/proposal-template.md
+++ b/proposal-template.md
@@ -1,31 +1,32 @@
-# Types
+# Import interface `proposal-interface-name`
+
+## Types
 
 ## <a href="#api_type_one" name="api_type_one"></a> `api-type-one`: record
 
-  Short description
-  
-  Explanation for developers using the API.
+Short description
+
+Explanation for developers using the API.
 
 Size: 16, Alignment: 8
 
 ### Record Fields
 
 - <a href="api_type_one.property1" name="api_type_one.property1"></a> [`property1`](#api_type_one.property1): `u64`
-
-
+  
+  
 - <a href="api_type_one.property2" name="api_type_one.property2"></a> [`property2`](#api_type_one.property2): `string`
-
-
-# Functions
+  
+  
+## Functions
 
 ----
 
 #### <a href="#api_function_one" name="api_function_one"></a> `api-function-one` 
 
-  Short description
-  
-  Explanation for developers using the API.
+Short description
+
+Explanation for developers using the API.
 ##### Results
 
 - [`api-type-one`](#api_type_one)
-

--- a/wasi-proposal-template.html
+++ b/wasi-proposal-template.html
@@ -1,0 +1,24 @@
+<h1>Import interface <code>proposal-interface-name</code></h1>
+<h2>Types</h2>
+<h2><a href="#api_type_one" name="api_type_one"></a> <a href="#api_type_one"><code>api-type-one</code></a>: record</h2>
+<p>Short description</p>
+<p>Explanation for developers using the API.</p>
+<p>Size: 16, Alignment: 8</p>
+<h3>Record Fields</h3>
+<ul>
+<li>
+<p><a href="api_type_one.property1" name="api_type_one.property1"></a> <a href="#api_type_one.property1"><code>property1</code></a>: <code>u64</code></p>
+</li>
+<li>
+<p><a href="api_type_one.property2" name="api_type_one.property2"></a> <a href="#api_type_one.property2"><code>property2</code></a>: <code>string</code></p>
+</li>
+</ul>
+<h2>Functions</h2>
+<hr />
+<h4><a href="#api_function_one" name="api_function_one"></a> <a href="#api_function_one"><code>api-function-one</code></a></h4>
+<p>Short description</p>
+<p>Explanation for developers using the API.</p>
+<h5>Results</h5>
+<ul>
+<li><a href="#api_function_one.result0" name="api_function_one.result0"></a> <code>result0</code>: <a href="#api_type_one"><a href="#api_type_one"><code>api-type-one</code></a></a></li>
+</ul>

--- a/wasi-proposal-template.md
+++ b/wasi-proposal-template.md
@@ -1,0 +1,33 @@
+# Import interface `proposal-interface-name`
+
+## Types
+
+## <a href="#api_type_one" name="api_type_one"></a> `api-type-one`: record
+
+Short description
+
+Explanation for developers using the API.
+
+Size: 16, Alignment: 8
+
+### Record Fields
+
+- <a href="api_type_one.property1" name="api_type_one.property1"></a> [`property1`](#api_type_one.property1): `u64`
+  
+  
+- <a href="api_type_one.property2" name="api_type_one.property2"></a> [`property2`](#api_type_one.property2): `string`
+  
+  
+## Functions
+
+----
+
+#### <a href="#api_function_one" name="api_function_one"></a> `api-function-one` 
+
+Short description
+
+Explanation for developers using the API.
+##### Results
+
+- <a href="#api_function_one.result0" name="api_function_one.result0"></a> `result0`: [`api-type-one`](#api_type_one)
+

--- a/wit/proposal-template.wit.md
+++ b/wit/proposal-template.wit.md
@@ -6,7 +6,16 @@
 
 [If you want to include examples of the API in use, these should be in the README and linked to from this file.]
 
-## api_type_one
+## `proposal-interface-name`
+
+```wit
+/// Short interface description.
+///
+/// Explanation for developers using the interface API.
+default interface proposal-interface-name {
+```
+
+## `api_type_one`
 
 ```wit
 /// Short description
@@ -20,7 +29,7 @@ record api-type-one {
 
 More rigorous specification details for the implementer go here, if needed.
 
-## api_function_one
+## `api_function_one`
 
 ```wit
 /// Short description
@@ -30,3 +39,7 @@ api-function-one: func() -> api-type-one
 ```
 
 If needed, this would explain what a compliant implementation MUST do, such as never returning an earlier result from a later call.
+
+```wit
+}
+```

--- a/wit/world.wit.md
+++ b/wit/world.wit.md
@@ -1,0 +1,12 @@
+This file contains a world that imports all interfaces in this proposal. Its
+primary purpose is to allow unified documentation to be easiy generated for
+the whole proposal.
+
+Proposals should edit replace the import below (and this sentence) with imports
+of their own interfaces.
+
+```wit
+default world wasi-proposal-template {
+    import proposal-interface-name: pkg.proposal-template.proposal-interface-name
+}
+```


### PR DESCRIPTION
Update to the latest wit-bindgen, including support for worlds and interfaces. This changes a few things about the directory layout:

 - Wit files are moved to a `wit` directory, to match how wit-bindgen expects packages to be layed out in their own directory.

 - There's also a wit/world.wit.md added, which contains a world that pulls in the interfaces in the repository, so that we can generate unified docuentation for the whole repository.

 - `*.abi.md` is now renamed to just `*.md`.

 - This also checks in an `.html` file rendered from the generated `.md` file.