### PR TITLE
Update to the latest wit-abi tag

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,4 +13,4 @@ jobs:
     - uses: actions/checkout@v2
     - uses: WebAssembly/wit-abi-up-to-date@v10
       with:
-        wit-abi-tag: wit-abi-0.7.0
+        wit-abi-tag: wit-abi-0.8.0


### PR DESCRIPTION
This updates to the latest wit-bindgen, which contains fixes for no_std mode in Rust guests.