### PR TITLE
Github .wit syntax highlighting

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# A hack to enable some degree of syntax highlighting on GitHub. Should be removed if GitHub ever receives native support for Wit files.
+*.wit linguist-language=Rust


### PR DESCRIPTION
Since https://github.com/WebAssembly/wasi-proposal-template/pull/7 .wit files are the canonical format for proposals. Github does not support .wit file syntax highlighting natively. 

This change instructs Github to use Rust syntax highlighting on .wit files. Now, this is most definitely not perfect, but it at least it colours the basics such as comments.

Example of this in action: https://github.com/WebAssembly/wasi-sockets/blob/9a559b1f0565d2f33f176e80edea6eefdbaff00b/wasi-tcp.wit