### PR TITLE
chore: add w3c license to template

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,3 @@
+All documents in this Repository are licensed by contributors
+under the 
+[W3C Document License](https://www.w3.org/Consortium/Legal/copyright-documents).


### PR DESCRIPTION
This will add the a file pointing to the [W3C Document License](https://www.w3.org/Consortium/Legal/copyright-documents).