### PR TITLE
docs: fix language for portability criteria

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,11 +16,14 @@ A proposed [WebAssembly System Interface](https://github.com/WebAssembly/WASI) A
 
 ### Champions
 
+<!---
+Please limit to one champion per company or organization
+-->
 - [Champion 1]
 - [Champion 2]
 - [etc.]
 
-### Phase 4 Advancement Criteria
+### Portability Criteria
 
 TODO before entering Phase 2.
 


### PR DESCRIPTION
This is to align language in the WASI phase process with all pre-existing WASI repos.

Phase 4 Advancement Criteria was renamed to Portability Criteria in WebAssembly/WASI#549, so rename it in this document.